### PR TITLE
fix: stop force-updating css variables

### DIFF
--- a/packages/web/src/web/cssVariables.ts
+++ b/packages/web/src/web/cssVariables.ts
@@ -192,7 +192,7 @@ export function useCssVariables<T extends CssVariableConfigurationObject>(
 
           // don't force if the current value is the same as the given one
           // or if the given one is empty
-          if (val && val[0] !== getCssVariableFor(val[1], name)) {
+          if (val[1] && val[0] !== getCssVariableFor(val[1], name)) {
             setCssVariableFor(val[1], name as string, val[0]);
           }
         },

--- a/packages/web/src/web/cssVariables.ts
+++ b/packages/web/src/web/cssVariables.ts
@@ -189,10 +189,11 @@ export function useCssVariables<T extends CssVariableConfigurationObject>(
         [result[key], wrap(element)] as any,
         (val: [CssVariable, HTMLElement]) => {
           if (!observing) return;
-          if (val) {
+
+          // don't force if the current value is the same as the given one
+          // or if the given one is empty
+          if (val && val[0] !== getCssVariableFor(val[1], name)) {
             setCssVariableFor(val[1], name as string, val[0]);
-          } else {
-            // todo remove?
           }
         },
         { lazy: isRef(element) }


### PR DESCRIPTION
This pull request fixes a case where the CSS variable would be added as a style on the selected element, hence making useless the observation of said element in cases where the style is not changed but a class or an attribute is. 

This version will behave as before, adding a style since we provide a value: 
```js
useCssVariables({
  onBackgroundColor: {
    name: "color-on-background",
    value: "red" // we define a value, so style is applied
  }
});
``` 

This version will behave as expected in the first PR, not adding a style if not required: 
```js
useCssVariables({
  onBackgroundColor: 'on-background-color' // we don't define a value, no style is applied
});
```