### PR TITLE
feat: Only update usePromise.result when the promise is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated [composition-api@0.5.0](https://github.com/vuejs/composition-api)
 - stop force-updating css variables #178 - Thanks @hawezo
 - [CSS variables](https://pikax.me/vue-composable/composable/web/cssVariables) - changed default options to `{ attributes: true, childList: true, subtree: true }`
+- [usePromise](https://pikax.me/vue-composable/composable/promise/promise) - do not reset `result` between executions
 
 ## 1.0.0-dev.15
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "minimist": "^1.2.5",
     "mock-socket": "^9.0.3",
     "rimraf": "^3.0.2",
-    "rollup": "^2.1.0",
+    "rollup": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript2": "^0.26.0",
     "ts-jest": "^25.2.1",

--- a/packages/core/__tests__/promise/promise.spec.ts
+++ b/packages/core/__tests__/promise/promise.spec.ts
@@ -1,5 +1,6 @@
 import { usePromise } from "../../src/promise/promise";
 import { nextTick } from "../utils";
+import { promisedTimeout } from "../../src/";
 
 describe("promise", () => {
   let cb: ((...args: any[]) => void) | null = null;
@@ -180,6 +181,23 @@ describe("promise", () => {
       loading: { value: true },
       error: { value: null }
     });
+  });
+
+  it("should only update result after the promise is resolved", async () => {
+    // result should not be set to `null` between executions
+    let v = 1;
+    const use = usePromise(x => promisedTimeout(20).then(() => (v = x)));
+
+    expect(use.result.value).toBe(null);
+
+    await use.exec(12);
+
+    expect(use.result.value).toBe(v);
+    use.exec(1);
+    await promisedTimeout(5);
+    expect(use.result.value).toBe(12);
+    await promisedTimeout(17);
+    expect(use.result.value).toBe(1);
   });
 
   describe("throw exception", () => {

--- a/packages/core/src/promise/promise.ts
+++ b/packages/core/src/promise/promise.ts
@@ -84,7 +84,6 @@ export function usePromise<T extends Promise<any>, TArgs extends Array<any>>(
   const exec = async (...args: TArgs): Promise<PromiseType<T> | undefined> => {
     loading.value = true;
     error.value = null;
-    result.value = null;
 
     let throwExp =
       args &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -9481,10 +9481,10 @@ rollup-pluginutils@2.8.2, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.1.0.tgz#552e248e397a06b9c6db878c0564ca4ee06729c9"
-  integrity sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==
+rollup@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.2.0.tgz#d82cfd6eda6d9561593a7e8a2fc0b72811a89b49"
+  integrity sha512-iAu/j9/WJ0i+zT0sAMuQnsEbmOKzdQ4Yxu5rbPs9aUCyqveI1Kw3H4Fi9NWfCOpb8luEySD2lDyFWL9CrLE8iw==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
Each call of `exec` it was assigning `null` to result, making usage of `watches` a bit more annoying