### PR TITLE
feat: add `injectFactory` composable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -129,7 +129,10 @@ module.exports = {
           title: "Misc",
           sidebarDepth: 1,
           collapsable: false,
-          children: [["composable/misc/sharedRef", "SharedRef"]]
+          children: [
+            ["composable/misc/sharedRef", "SharedRef"],
+            ["composable/misc/injectFactory", "injectFactory"]
+          ]
         },
         {
           title: "Storage",

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ Check out the [examples folder](examples) or start hacking on [codesandbox](http
 ### MISC
 
 - [sharedRef](https://pikax.me/vue-composable/composable/misc/sharedRef) - cross-tab reactive `ref`
+- [injectFactory](https://pikax.me/vue-composable/composable/misc/injectFactory) - same as [inject](https://vue-composition-api-rfc.netlify.app/api.html#dependency-injection) but allows you to have a factory as default value
 
 ### Storage
 

--- a/docs/api/vue-composable.api.md
+++ b/docs/api/vue-composable.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { ComputedRef } from "@vue/runtime-core";
+import { InjectionKey } from "@vue/runtime-core";
 import { Plugin as Plugin_2 } from "@vue/runtime-core";
 import { provide } from "@vue/runtime-core";
 import { Ref } from "@vue/runtime-core";
@@ -408,6 +409,18 @@ export interface i18nResult<TLocales, TMessages extends any = i18n> {
   locales: Readonly<Ref<Readonly<Array<TLocales>>>>;
   removeLocale(locale: TLocales): void;
 }
+
+// @public (undocumented)
+export function injectFactory<T>(
+  key: InjectionKey<T> | string,
+  defaultValueFactory: () => Promise<T>
+): Promise<T>;
+
+// @public (undocumented)
+export function injectFactory<T>(
+  key: InjectionKey<T> | string,
+  defaultValueFactory: () => T
+): T;
 
 // @public (undocumented)
 export interface IntersectionObserverOptions {

--- a/docs/composable/misc/injectFactory.md
+++ b/docs/composable/misc/injectFactory.md
@@ -1,0 +1,42 @@
+# injectFactory
+
+> Same as [inject](https://vue-composition-api-rfc.netlify.app/api.html#dependency-injection) but allows you to have a factory as default value.
+
+## Parameters
+
+```js
+import { injectFactory } from "vue-composable";
+
+const value = injectFactory(key, factory);
+```
+
+| Parameters | Type                                 | Required | Description                                 |
+| ---------- | ------------------------------------ | -------- | ------------------------------------------- |
+| key        | `String|Symbol`                      | `true`   | key                                         |
+| factory    | `Function<T> | Function<Promise<T>>` | `true`   | Will be called if there's no value provided |
+
+### Code
+
+```ts
+const users = injectFactory("myValue", () => {
+  if (new Date().getDate() === 2) {
+    return {
+      a: 1
+    };
+  }
+
+  return {
+    b: 1
+  };
+});
+
+// promise
+const users = injectFactory("myValue", () =>
+  axios.get("/users").then(x => x.data)
+);
+if (isPromise(users)) {
+  // no value found, we can handle it
+} else {
+  // users provided
+}
+```

--- a/packages/vue-composable/README.md
+++ b/packages/vue-composable/README.md
@@ -76,6 +76,7 @@ Check our [documentation](https://pikax.me/vue-composable/)
 ### MISC
 
 - [sharedRef](https://pikax.me/vue-composable/composable/misc/sharedRef) - cross-tab reactive `ref`
+- [injectFactory](https://pikax.me/vue-composable/composable/misc/injectFactory) - same as [inject](https://vue-composition-api-rfc.netlify.app/api.html#dependency-injection) but allows you to have a factory as default value
 
 ### Storage
 

--- a/packages/vue-composable/__tests__/misc/injectFactory.spec.ts
+++ b/packages/vue-composable/__tests__/misc/injectFactory.spec.ts
@@ -1,0 +1,54 @@
+import { injectFactory } from "../../src";
+import { provide } from "../../src/api";
+import { createVue } from "../utils";
+
+describe("injectFactory", () => {
+  it("should work", () => {
+    const key = "hello";
+
+    const fn = jest.fn();
+
+    const comp = {
+      template: `<div/>`,
+      setup() {
+        injectFactory(key, fn);
+      },
+    };
+
+    createVue({
+      components: {
+        comp,
+      },
+      template: `<comp/>`,
+    }).mount();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call injectFactory", () => {
+    const key = "hello";
+
+    const fn = jest.fn();
+
+    const comp = {
+      template: `<div/>`,
+      setup() {
+        injectFactory(key, fn);
+      },
+    };
+
+    createVue({
+      components: {
+        comp,
+      },
+      template: `<comp/>`,
+
+      setup() {
+        provide(key, 1);
+        injectFactory(key, fn);
+      },
+    }).mount();
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vue-composable/src/misc/index.ts
+++ b/packages/vue-composable/src/misc/index.ts
@@ -1,2 +1,3 @@
 export * from "./matchMedia";
 export * from "./sharedRef";
+export * from "./injectFactory";

--- a/packages/vue-composable/src/misc/injectFactory.ts
+++ b/packages/vue-composable/src/misc/injectFactory.ts
@@ -1,0 +1,21 @@
+import { inject, InjectionKey } from "../api";
+
+export function injectFactory<T>(
+  key: InjectionKey<T> | string,
+  defaultValueFactory: () => Promise<T>
+): Promise<T>;
+export function injectFactory<T>(
+  key: InjectionKey<T> | string,
+  defaultValueFactory: () => T
+): T;
+export function injectFactory<T>(
+  key: InjectionKey<T> | string,
+  defaultValueFactory: () => Promise<T> | T
+): T {
+  const uniqueSymbol = Symbol();
+  const r = inject<T | Symbol>(key, uniqueSymbol);
+  if (r === uniqueSymbol) {
+    return defaultValueFactory() as T;
+  }
+  return r as T;
+}

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ Check our [documentation](https://pikax.me/vue-composable/)
 ### MISC
 
 - [sharedRef](https://pikax.me/vue-composable/composable/misc/sharedRef) - cross-tab reactive `ref`
+- [injectFactory](https://pikax.me/vue-composable/composable/misc/injectFactory) - same as [inject](https://vue-composition-api-rfc.netlify.app/api.html#dependency-injection) but allows you to have a factory as default value
 
 ### Storage
 


### PR DESCRIPTION
`InjectFactory` composable

Allows to inject to default to the factory result, instead of default value.

The factory will only be called when the value doesn't exist

### Motivation

Sometimes building the `defaultValue` might be too costly to build every time we want to inject

```ts
// normal usage
injectFactory(myKey, ()=> { /* Heavy method */})

// promised based
await injectFactory(myKey, ()=> { /* Promised Heavy method */})
```