### PR TITLE
feat: single package v2 and v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-dev.37",
+  "version": "1.0.0",
   "name": "vue-composable-monorepo",
   "workspaces": [
     "packages/*",
@@ -16,14 +16,11 @@
     "type": "git",
     "url": "git+https://github.com/pikax/vue-composable.git"
   },
-  "module": "dist/vue-composable.es.js",
+  "module": "dist/vue-composable.esm-bundler.js",
   "typings": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "private": true,
   "scripts": {
-    "prebuild": "rimraf dist",
+    "postinstall": "node ./scripts/postinstall.js",
     "build": "node scripts/build.js",
     "build:vue2": "yarn build --version=2",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.0-dev.37",
   "name": "vue-composable-monorepo",
   "workspaces": [
     "packages/*",
     "examples/*"
   ],
   "description": "Vue composition-api composable components",
-  "main": "index.js",
   "author": {
     "name": "pikax",
     "email": "carlos@hypermob.co.uk"
@@ -16,8 +15,6 @@
     "type": "git",
     "url": "git+https://github.com/pikax/vue-composable.git"
   },
-  "module": "dist/vue-composable.esm-bundler.js",
-  "typings": "dist/index.d.ts",
   "private": true,
   "scripts": {
     "build": "node scripts/build.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "typings": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "postinstall": "node ./scripts/postinstall.js",
     "build": "node scripts/build.js",
     "build:vue2": "yarn build --version=2",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1",

--- a/packages/axios/README.md
+++ b/packages/axios/README.md
@@ -12,7 +12,7 @@ Use Axios library with the [composition-api](https://github.com/vuejs/compositio
 
 # Vue 3
 
-[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is supported on the [@next](https://www.npmjs.com/package/vue-composable/v/next)
+[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is fully supported
 
 ## Installing
 
@@ -29,10 +29,10 @@ npm install @vue/composition-api @vue-composable/axios
 # vue-next / vue@3.0.0-beta
 
 # install with yarn
-yarn add @vue-composable/axios@next
+yarn add @vue-composable/axios
 
 # install with npm
-npm install @vue-composable/axios@next
+npm install @vue-composable/axios
 ```
 
 ## Documentation

--- a/packages/axios/api-extractor.json
+++ b/packages/axios/api-extractor.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../api-extractor.json",
-  "mainEntryPointFilePath": "./dist/packages/<unscopedPackageName>/src/index.d.ts",
-  "dtsRollup": {
-    "untrimmedFilePath": "./dist/<unscopedPackageName>.d.ts"
-  }
-}

--- a/packages/axios/api-extractor.v2.json
+++ b/packages/axios/api-extractor.v2.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/v2/packages/<unscopedPackageName>/src/index.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "./dist/v2/<unscopedPackageName>.d.ts"
+  }
+}

--- a/packages/axios/api-extractor.v3.json
+++ b/packages/axios/api-extractor.v3.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/v3/packages/<unscopedPackageName>/src/index.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "./dist/v3/<unscopedPackageName>.d.ts"
+  }
+}

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-composable/axios",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.37",
   "description": "@vue-composable/axios",
   "main": "index.js",
   "module": "dist/axios.esm-bundler.js",
@@ -44,7 +44,7 @@
     "vue-composable-axios-fix": "./scripts/postinstall.js"
   },
   "dependencies": {
-    "vue-composable": "^1.0.0"
+    "vue-composable": "^1.0.0-dev.37"
   },
   "peerDependencies2": {
     "@vue/composition-api": "^1.0.0-beta.2",
@@ -59,9 +59,5 @@
     "@types/node": "^14.0.23",
     "@vue/runtime-core": "^3.0.0-beta.24",
     "typescript": "^3.9.7"
-  },
-  "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-beta.2",
-    "axios": "^0.19.2"
   }
 }

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -59,5 +59,9 @@
     "@types/node": "^14.0.23",
     "@vue/runtime-core": "^3.0.0-beta.24",
     "typescript": "^3.9.7"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.0.0-beta.2",
+    "axios": "^0.19.2"
   }
 }

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-composable/axios",
-  "version": "1.0.0-alpha.37",
+  "version": "1.0.0",
   "description": "@vue-composable/axios",
   "main": "index.js",
   "module": "dist/axios.esm-bundler.js",
@@ -38,11 +38,7 @@
   "homepage": "https://pikax.me/vue-composable/composable/external/axios.html",
   "sideEffects": false,
   "dependencies": {
-    "vue-composable": "^1.0.0-dev.37"
-  },
-  "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-beta.2",
-    "axios": "^0.19.2"
+    "vue-composable": "^1.0.0"
   },
   "peerDependencies2": {
     "@vue/composition-api": "^1.0.0-beta.2",

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -38,10 +38,10 @@
   "homepage": "https://pikax.me/vue-composable/composable/external/axios.html",
   "sideEffects": false,
   "dependencies": {
-    "vue-composable": "^1.0.0-alpha.32"
+    "vue-composable": "^1.0.0-dev.37"
   },
   "peerDependencies": {
-    "@vue/runtime-core": "^3.0.0-beta.24",
+    "@vue/composition-api": "^1.0.0-beta.2",
     "axios": "^0.19.2"
   },
   "peerDependencies2": {

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -37,6 +37,12 @@
   },
   "homepage": "https://pikax.me/vue-composable/composable/external/axios.html",
   "sideEffects": false,
+  "scripts": {
+    "postinstall": "node ./scripts/postinstall.js"
+  },
+  "bin": {
+    "vue-composable-axios-fix": "./scripts/postinstall.js"
+  },
   "dependencies": {
     "vue-composable": "^1.0.0"
   },

--- a/packages/axios/scripts/postinstall.js
+++ b/packages/axios/scripts/postinstall.js
@@ -44,6 +44,11 @@ function switchPeerdependencies(version) {
 function switchVersion(version) {
   const dist = path.join(dir, "dist");
   const versionPath = path.join(dist, `v${version}`);
+
+  // local dev
+  if (!fs.existsSync(versionPath)) {
+    return;
+  }
   const files = fs.readdirSync(versionPath);
 
   files.forEach(f => {
@@ -57,7 +62,7 @@ const Vue = loadModule("vue");
 
 if (!Vue || typeof Vue.version !== "string") {
   console.warn(
-    "[vue-composable-axios] Vue is not detected in the dependencies. Please install Vue first."
+    "[vue-composable] Vue is not detected in the dependencies. Please install Vue first."
   );
 } else if (Vue.version.startsWith("2.")) {
   const VCA = loadModule("@vue/composition-api");
@@ -69,6 +74,6 @@ if (!Vue || typeof Vue.version !== "string") {
   switchVersion(3);
 } else {
   console.warn(
-    `[vue-composable-axios] Vue version v${Vue.version} is not suppported.`
+    `[vue-composable] Vue version v${Vue.version} is not suppported.`
   );
 }

--- a/packages/axios/scripts/postinstall.js
+++ b/packages/axios/scripts/postinstall.js
@@ -1,0 +1,74 @@
+// based on https://github.com/antfu/vue-demi/blob/060127b7ededfb2ab64e909f08787504c083df60/scripts/postinstall.js
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const dir = path.resolve(__dirname, "..");
+const agent = (process.env.npm_config_user_agent || "npm").split("/")[0];
+const userRoot = path.resolve(dir, "../..");
+
+const AgentCommands = {
+  npm: "npm i",
+  yarn: "yarn add",
+  pnpm: "pnpm add",
+  cnpm: "cnpm i"
+};
+
+function loadModule(name) {
+  try {
+    return require(name);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function installModules(names) {
+  const command = AgentCommands[agent] || AgentCommands.npm;
+  names = Array.isArray(names) ? names : [names];
+  execSync(`${command} ${names.join(" ")}`, {
+    stdio: "inherit",
+    cwd: userRoot
+  });
+}
+
+function switchPeerdependencies(version) {
+  const pkg = require(`${dir}/package.json`);
+  pkg.peerDependencies = pkg["peerDependencies" + version];
+  return fs.writeFileSync(
+    `${dir}/package.json`,
+    JSON.stringify(pkg, undefined, 2)
+  );
+}
+
+function switchVersion(version) {
+  const dist = path.join(dir, "dist");
+  const versionPath = path.join(dist, `v${version}`);
+  const files = fs.readdirSync(versionPath);
+
+  files.forEach(f => {
+    fs.copyFileSync(path.join(versionPath, f), path.join(dist, f));
+  });
+
+  switchPeerdependencies(version);
+}
+
+const Vue = loadModule("vue");
+
+if (!Vue || typeof Vue.version !== "string") {
+  console.warn(
+    "[vue-composable-axios] Vue is not detected in the dependencies. Please install Vue first."
+  );
+} else if (Vue.version.startsWith("2.")) {
+  const VCA = loadModule("@vue/composition-api");
+  if (!VCA) {
+    installModules(["@vue/composition-api"]);
+  }
+  switchVersion(2);
+} else if (Vue.version.startsWith("3.")) {
+  switchVersion(3);
+} else {
+  console.warn(
+    `[vue-composable-axios] Vue version v${Vue.version} is not suppported.`
+  );
+}

--- a/packages/vue-composable/README.md
+++ b/packages/vue-composable/README.md
@@ -19,7 +19,7 @@ This library aim is to be one stop shop for many real-world composable functions
 
 # Vue 3
 
-[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is supported on the [@next](https://www.npmjs.com/package/vue-composable/v/next)
+[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is fully supported.
 
 ## Installing
 
@@ -32,14 +32,13 @@ yarn add @vue/composition-api vue-composable
 # install with npm
 npm install @vue/composition-api vue-composable
 
-
-# vue-next / vue@3.0.0-beta
+# vue 3
 
 # install with yarn
-yarn add vue-composable@next
+yarn add vue-composable
 
 # install with npm
-npm install vue-composable@next
+npm install vue-composable
 ```
 
 ## Documentation
@@ -141,7 +140,7 @@ Check our [documentation](https://pikax.me/vue-composable/)
 > New packages needed
 
 - [Axios](https://pikax.me/vue-composable/composable/external/axios) - [@vue-composable/axios](https://www.npmjs.com/package/@vue-composable/axios) reactive `axios` wrapper client
-- [makeAxios](https://pikax.me/vue-composable/composable/external/makeAxios) - [@vue-composable/makeAxios](https://www.npmjs.com/package/@vue-composable/makeAxios) wrap your `axios` instance
+- [makeAxios](https://pikax.me/vue-composable/composable/external/makeAxios) - [@vue-composable/axios](https://www.npmjs.com/package/@vue-composable/axios) wrap your `axios` instance
 
 ## Information
 

--- a/packages/vue-composable/api-extractor.json
+++ b/packages/vue-composable/api-extractor.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../api-extractor.json",
-  "mainEntryPointFilePath": "./dist/packages/<unscopedPackageName>/src/index.d.ts",
-  "dtsRollup": {
-    "untrimmedFilePath": "./dist/<unscopedPackageName>.d.ts"
-  }
-}

--- a/packages/vue-composable/api-extractor.v2.json
+++ b/packages/vue-composable/api-extractor.v2.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/v2/packages/<unscopedPackageName>/src/index.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "./dist/v2/<unscopedPackageName>.d.ts"
+  }
+}

--- a/packages/vue-composable/api-extractor.v3.json
+++ b/packages/vue-composable/api-extractor.v3.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/v3/packages/<unscopedPackageName>/src/index.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "./dist/v3/<unscopedPackageName>.d.ts"
+  }
+}

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-composable",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.37",
   "description": "vue-composable",
   "main": "index.js",
   "module": "dist/vue-composable.esm-bundler.js",
@@ -47,10 +47,6 @@
     "@vue/runtime-core": "^3.0.0-beta.24"
   },
   "peerDependencies2": {
-    "@vue/composition-api": "^1.0.0-beta.2",
-    "vue": "^2.6.10"
-  },
-  "peerDependencies": {
     "@vue/composition-api": "^1.0.0-beta.2",
     "vue": "^2.6.10"
   }

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-composable",
-  "version": "1.0.0-alpha.37",
+  "version": "1.0.0",
   "description": "vue-composable",
   "main": "index.js",
   "module": "dist/vue-composable.esm-bundler.js",
@@ -39,10 +39,6 @@
   "sideEffects": false,
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js"
-  },
-  "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-beta.2",
-    "vue": "^2.6.10"
   },
   "peerDependencies3": {
     "@vue/runtime-core": "^3.0.0-beta.24"

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -40,6 +40,9 @@
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js"
   },
+  "bin": {
+    "vue-composable-fix": "./scripts/postinstall.js"
+  },
   "peerDependencies3": {
     "@vue/runtime-core": "^3.0.0-beta.24"
   },

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -49,5 +49,9 @@
   "peerDependencies2": {
     "@vue/composition-api": "^1.0.0-beta.2",
     "vue": "^2.6.10"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.0.0-beta.2",
+    "vue": "^2.6.10"
   }
 }

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -7,7 +7,8 @@
   "unpkg": "dist/vue-composable.global.js",
   "files": [
     "index.js",
-    "dist"
+    "dist",
+    "scripts"
   ],
   "types": "dist/vue-composable.d.ts",
   "buildOptions": {
@@ -36,6 +37,9 @@
   },
   "homepage": "https://pikax.me/vue-composable/composable",
   "sideEffects": false,
+  "scripts": {
+    "postinstall": "node ./scripts/postinstall.js"
+  },
   "peerDependencies": {
     "@vue/composition-api": "^1.0.0-beta.2",
     "vue": "^2.6.10"

--- a/packages/vue-composable/scripts/postinstall.js
+++ b/packages/vue-composable/scripts/postinstall.js
@@ -44,6 +44,11 @@ function switchPeerdependencies(version) {
 function switchVersion(version) {
   const dist = path.join(dir, "dist");
   const versionPath = path.join(dist, `v${version}`);
+
+  // local dev
+  if (!fs.existsSync(versionPath)) {
+    return;
+  }
   const files = fs.readdirSync(versionPath);
 
   files.forEach(f => {

--- a/packages/vue-composable/scripts/postinstall.js
+++ b/packages/vue-composable/scripts/postinstall.js
@@ -1,0 +1,74 @@
+// based on https://github.com/antfu/vue-demi/blob/060127b7ededfb2ab64e909f08787504c083df60/scripts/postinstall.js
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const dir = path.resolve(__dirname, "..");
+const agent = (process.env.npm_config_user_agent || "npm").split("/")[0];
+const userRoot = path.resolve(dir, "../..");
+
+const AgentCommands = {
+  npm: "npm i",
+  yarn: "yarn add",
+  pnpm: "pnpm add",
+  cnpm: "cnpm i"
+};
+
+function loadModule(name) {
+  try {
+    return require(name);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function installModules(names) {
+  const command = AgentCommands[agent] || AgentCommands.npm;
+  names = Array.isArray(names) ? names : [names];
+  execSync(`${command} ${names.join(" ")}`, {
+    stdio: "inherit",
+    cwd: userRoot
+  });
+}
+
+function switchPeerdependencies(version) {
+  const pkg = require(`${dir}/package.json`);
+  pkg.peerDependencies = pkg["peerDependencies" + version];
+  return fs.writeFileSync(
+    `${dir}/package.json`,
+    JSON.stringify(pkg, undefined, 2)
+  );
+}
+
+function switchVersion(version) {
+  const dist = path.join(dir, "dist");
+  const versionPath = path.join(dist, `v${version}`);
+  const files = fs.readdirSync(versionPath);
+
+  files.forEach(f => {
+    fs.copyFileSync(path.join(versionPath, f), path.join(dist, f));
+  });
+
+  switchPeerdependencies(version);
+}
+
+const Vue = loadModule("vue");
+
+if (!Vue || typeof Vue.version !== "string") {
+  console.warn(
+    "[vue-composable] Vue is not detected in the dependencies. Please install Vue first."
+  );
+} else if (Vue.version.startsWith("2.")) {
+  const VCA = loadModule("@vue/composition-api");
+  if (!VCA) {
+    installModules(["@vue/composition-api"]);
+  }
+  switchVersion(2);
+} else if (Vue.version.startsWith("3.")) {
+  switchVersion(3);
+} else {
+  console.warn(
+    `[vue-composable] Vue version v${Vue.version} is not suppported.`
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ This library aim is to be one stop shop for many real-world composable functions
 
 # Vue 3
 
-[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is supported on the [@next](https://www.npmjs.com/package/vue-composable/v/next)
+[Vue3](https://github.com/vuejs/vue-next) aka [vue-next](https://github.com/vuejs/vue-next) is fully supported.
 
 ## Installing
 
@@ -32,14 +32,13 @@ yarn add @vue/composition-api vue-composable
 # install with npm
 npm install @vue/composition-api vue-composable
 
-
-# vue-next / vue@3.0.0-beta
+# vue 3
 
 # install with yarn
-yarn add vue-composable@next
+yarn add vue-composable
 
 # install with npm
-npm install vue-composable@next
+npm install vue-composable
 ```
 
 ## Documentation
@@ -141,7 +140,7 @@ Check our [documentation](https://pikax.me/vue-composable/)
 > New packages needed
 
 - [Axios](https://pikax.me/vue-composable/composable/external/axios) - [@vue-composable/axios](https://www.npmjs.com/package/@vue-composable/axios) reactive `axios` wrapper client
-- [makeAxios](https://pikax.me/vue-composable/composable/external/makeAxios) - [@vue-composable/makeAxios](https://www.npmjs.com/package/@vue-composable/makeAxios) wrap your `axios` instance
+- [makeAxios](https://pikax.me/vue-composable/composable/external/makeAxios) - [@vue-composable/axios](https://www.npmjs.com/package/@vue-composable/axios) wrap your `axios` instance
 
 ## Information
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ const name = path.basename(packageDir);
 const resolve = p => path.resolve(packageDir, p);
 const pkg = require(resolve(`package.json`));
 const packageOptions = pkg.buildOptions || {};
+const vueVersion = process.env.VUE_VERSION;
 
 const knownExternals = fs.readdirSync(packagesDir);
 
@@ -23,15 +24,15 @@ let hasTSChecked = false;
 
 const configs = {
   "esm-bundler": {
-    file: resolve(`dist/${name}.esm-bundler.js`),
+    file: resolve(`dist/v${vueVersion}/${name}.esm-bundler.js`),
     format: `es`
   },
   cjs: {
-    file: resolve(`dist/${name}.cjs.js`),
+    file: resolve(`dist/v${vueVersion}/${name}.cjs.js`),
     format: `cjs`
   },
   global: {
-    file: resolve(`dist/${name}.global.js`),
+    file: resolve(`dist/v${vueVersion}/${name}.global.js`),
     format: `iife`,
     globals: {
       "@vue/composition-api": "vueCompositionApi",
@@ -41,7 +42,7 @@ const configs = {
     }
   },
   esm: {
-    file: resolve(`dist/${name}.esm.js`),
+    file: resolve(`dist/v${vueVersion}/${name}.esm.js`),
     format: `es`,
     external: ["vue", "@vue/composition-api", "axios"]
   }
@@ -197,7 +198,7 @@ function createReplacePlugin(
 function createProductionConfig(format) {
   return createConfig(
     {
-      file: resolve(`dist/${name}.${format}.prod.js`),
+      file: resolve(`dist/v${vueVersion}/${name}.${format}.prod.js`),
       format: configs[format].format
     },
     configs[format].plugins || [],
@@ -210,7 +211,7 @@ function createMinifiedConfig(format) {
   return createConfig(
     {
       ...configs[format],
-      file: resolve(`dist/${name}.${format}.prod.js`),
+      file: resolve(`dist/v${vueVersion}/${name}.${format}.prod.js`),
       format: configs[format].format
     },
     [

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,63 @@
+// based on https://github.com/antfu/vue-demi/blob/060127b7ededfb2ab64e909f08787504c083df60/scripts/postinstall.js
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const dir = path.resolve(__dirname, "..");
+const agent = (process.env.npm_config_user_agent || "npm").split("/")[0];
+const userRoot = path.resolve(dir, "../..");
+
+const AgentCommands = {
+  npm: "npm i",
+  yarn: "yarn add",
+  pnpm: "pnpm add",
+  cnpm: "cnpm i"
+};
+
+function loadModule(name) {
+  try {
+    return require(name);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function installModules(names) {
+  const command = AgentCommands[agent] || AgentCommands.npm;
+  names = Array.isArray(names) ? names : [names];
+  execSync(`${command} ${names.join(" ")}`, {
+    stdio: "inherit",
+    cwd: userRoot
+  });
+}
+
+function switchVersion(version) {
+  const dist = path.join(dir, "dist");
+  const versionPath = path.join(dist, `v${version}`);
+  const files = fs.readdirSync(versionPath);
+
+  files.forEach(f => {
+    fs.copyFile(path.join(versionPath, f), path.join(dist, f));
+  });
+}
+
+const Vue = loadModule("vue");
+
+if (!Vue || typeof Vue.version !== "string") {
+  console.warn(
+    "[vue-composable] Vue is not detected in the dependencies. Please install Vue first."
+  );
+} else if (Vue.version.startsWith("2.")) {
+  const VCA = loadModule("@vue/composition-api");
+  if (!VCA) {
+    installModules(["@vue/composition-api"]);
+  }
+  switchVersion(2);
+} else if (Vue.version.startsWith("3.")) {
+  switchVersion(3);
+} else {
+  console.warn(
+    `[vue-composable] Vue version v${Vue.version} is not suppported.`
+  );
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -32,14 +32,30 @@ function installModules(names) {
   });
 }
 
+function switchPeerdependencies(version) {
+  const pkg = require(`${dir}/package.json`);
+  pkg.peerDependencies = pkg["peerDependencies" + version];
+  return fs.writeFileSync(
+    `${dir}/package.json`,
+    JSON.stringify(pkg, undefined, 2)
+  );
+}
+
 function switchVersion(version) {
   const dist = path.join(dir, "dist");
   const versionPath = path.join(dist, `v${version}`);
+
+  // local dev
+  if (!fs.existsSync(versionPath)) {
+    return;
+  }
   const files = fs.readdirSync(versionPath);
 
   files.forEach(f => {
-    fs.copyFile(path.join(versionPath, f), path.join(dist, f));
+    fs.copyFileSync(path.join(versionPath, f), path.join(dist, f));
   });
+
+  switchPeerdependencies(version);
 }
 
 const Vue = loadModule("vue");

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -54,6 +54,12 @@ async function run() {
   for (const version of versions) {
     for (const target of buildTargets) {
       await build(target, version);
+
+      // fs.remove(path.resolve(`packages/${target}/scripts/postinstall.js`));
+      await fs.copyFile(
+        "./scripts/postinstall.js",
+        path.resolve(`packages/${target}/scripts/postinstall.js`)
+      );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,13 +1469,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vue-composable/axios@^1.0.0-dev.32":
-  version "1.0.0-dev.36"
-  resolved "https://registry.yarnpkg.com/@vue-composable/axios/-/axios-1.0.0-dev.36.tgz#03e0fcb682c21abc33b096f0e247267efffa85c9"
-  integrity sha512-aqNFnMkwrkAyNMTScLJEsqBlpnAo/4ypdTI0yhu881UJT07naIAwTwMSgCL6z0aLfHQYAYE4nocC+t84EFhixQ==
-  dependencies:
-    vue-composable "^1.0.0-alpha.32"
-
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz#048fe579958da408fb7a8b2a3ec050b50a661040"
@@ -11713,11 +11706,6 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-vue-composable@^1.0.0-dev.32:
-  version "1.0.0-dev.36"
-  resolved "https://registry.yarnpkg.com/vue-composable/-/vue-composable-1.0.0-dev.36.tgz#584b8453ed48ed784fa491e00afd8511ac894331"
-  integrity sha512-FaQq1WZeOIKwk50tt1n9z1DT7mH46DNT7J7qn0mhrlCPNWNqkvkCWt32MVCwFHFd8Rz3Y1+8apeBwrnxKcz4zw==
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"


### PR DESCRIPTION
No more `tag` based dependency for v2 and v3 🙂 

Heavily inspired by [@vue-demi](https://www.npmjs.com/package/vue-demi)! 

Unfortunately can't use `vue-demi` since there's a few changes on some composables based on the vue version.

Thank you @antfu  💪 