### PR TITLE
feat(validation): add to $errors if the validator has $message

### DIFF
--- a/packages/vue-composable/__tests__/validation/validation.spec.ts
+++ b/packages/vue-composable/__tests__/validation/validation.spec.ts
@@ -190,6 +190,30 @@ describe("validation", () => {
     ]);
   });
 
+  it("should store $errors if $message is available", () => {
+    const $message = "Invalid value";
+    const v = useValidation({
+      input: {
+        $value: "",
+        required: {
+          $validator(x: string) {
+            return false;
+          },
+          $message
+        }
+      },
+      otherInput: {
+        $value: "",
+        required(x: string) {
+          return false;
+        }
+      }
+    });
+
+    expect(v.input.$errors).toMatchObject([$message]);
+    expect(v.otherInput.$errors).toMatchObject([]);
+  });
+
   describe("render", () => {
     it("should show error", async () => {
       const required = (x: any) => !!x;


### PR DESCRIPTION
fix #493 

If a validator has a $message and the validations fails it will be added to the $errors


```ts
    const $message = "Invalid value";
    const v = useValidation({
      input: {
        $value: "",
        required: {
          $validator(x: string) {
            return false;
          },
          $message
        }
      },
      otherInput: {
        $value: "",
        required(x: string) {
          return false;
        }
      }
    });

    expect(v.input.$errors).toMatchObject([$message]);
    expect(v.otherInput.$errors).toMatchObject([]);
```