### PR TITLE
fix example of useEvent

### DIFF
--- a/docs/composable/event/event.md
+++ b/docs/composable/event/event.md
@@ -43,7 +43,7 @@ export default {
       x: 0,
       y: 0
     });
-    const remove = useEvent(elref, "mousemove", e => {
+    const { remove } = useEvent(elref, "mousemove", e => {
       state.x = e.x;
       state.y = e.y;
     });


### PR DESCRIPTION
I haven't used this (or even install the library,) but I'm guessing `remove` is to be destructured.