### PR TITLE
Update validation.md

### DIFF
--- a/docs/composable/validation/validation.md
+++ b/docs/composable/validation/validation.md
@@ -250,6 +250,7 @@ interface ValidationGroupResult {
 
 <script>
 import { defineComponent, ref, reactive, computed } from "@vue/composition-api";
+import { required } from '@vuelidate/validators'
 import { useValidation } from "vue-composable";
 
 const required = x => !!x;
@@ -272,7 +273,7 @@ export default defineComponent({
       password: {
         $value: password,
         required: {
-          $validator: required,
+          $validator: required.$validator,
           $message: ref("password is required")
         }
       },


### PR DESCRIPTION
2 proposed changes here.

- Add reference to vuelidate lib for consuming required
- Update $validator to required.$validator

Kept on getting 'type f is not a function' returned as the error message.
Specifying required.$validator resolved this issue.