### PR TITLE
feat(devtools): add `useDevtoolsComponentState`

### DIFF
--- a/docs/api/vue-composable.api.md
+++ b/docs/api/vue-composable.api.md
@@ -4,13 +4,16 @@
 
 ```ts
 import { App } from "@vue/runtime-core";
+import { ComponentState } from "@vue/devtools-api";
 import { ComputedRef } from "@vue/runtime-core";
+import { Context } from "vm";
 import { CustomInspectorNode } from "@vue/devtools-api";
 import { CustomInspectorOptions } from "@vue/devtools-api";
 import { CustomInspectorState } from "@vue/devtools-api";
 import { DeepReadonly } from "@vue/runtime-core";
 import { DevtoolsPluginApi } from "@vue/devtools-api";
 import { InjectionKey } from "@vue/runtime-core";
+import { InspectedComponentData } from "@vue/devtools-api";
 import { Plugin as Plugin_2 } from "@vue/runtime-core";
 import { provide } from "@vue/runtime-core";
 import { Ref } from "@vue/runtime-core";
@@ -404,6 +407,12 @@ export interface DevtoolInspectorNodeStateValue {
   type: string;
   // (undocumented)
   value: any;
+}
+
+// @public (undocumented)
+export interface DevtoolsComponentStateOptions {
+  multiple: boolean;
+  type: string;
 }
 
 // @public (undocumented)
@@ -1354,6 +1363,23 @@ export function useDebounce<T extends Procedure>(
 
 // @public (undocumented)
 export const UseDevtoolsApp: (app: App, id?: string, label?: string) => void;
+
+// @public (undocumented)
+export function useDevtoolsComponentState(
+  getState: (
+    instanceData: InspectedComponentData,
+    ctx: Context
+  ) => ComponentState[]
+): void;
+
+// @public (undocumented)
+export function useDevtoolsComponentState(state: ComponentState[]): void;
+
+// @public (undocumented)
+export function useDevtoolsComponentState(
+  state: Record<string, object | ComponentState>,
+  options?: DevtoolsComponentStateOptions
+): void;
 
 // @public (undocumented)
 export function useDevtoolsInspector(

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -60,5 +60,9 @@
     "@types/node": "^14.6.0",
     "@vue/runtime-core": "^3.0.0-rc.4",
     "typescript": "^4.0.2"
+  },
+  "peerDependencies": {
+    "@vue/runtime-core": "^3.0.0-rc.2",
+    "axios": "^0.19.2"
   }
 }

--- a/packages/vue-composable/README.md
+++ b/packages/vue-composable/README.md
@@ -177,6 +177,77 @@ app.use(VueComposableDevtools, {
 app.mount("#app");
 ```
 
+### Component State
+
+To add properties to the component inspector tab
+[ComponentState](https://github.com/vuejs/vue-devtools/blob/next/packages/api/src/api/component.ts#L68)
+
+```ts
+const bar = "bar";
+useDevtoolsComponentState(
+  {
+    bar,
+  },
+  {
+    type: "custom composable", // change group
+  }
+);
+
+const baz = () => "baz";
+useDevtoolsComponentState({ baz });
+// no duplicates added by default
+useDevtoolsComponentState({ baz });
+
+const the = 42;
+useDevtoolsComponentState({ the });
+// to allow multiple same key
+useDevtoolsComponentState({ the }, { duplicate: true });
+
+// use a devtools api list directly
+interface StateBase {
+  key: string;
+  value: any;
+  editable: boolean;
+  objectType?: "ref" | "reactive" | "computed" | "other";
+  raw?: string;
+  type?: string;
+}
+useDevtoolsComponentState([
+  {
+    key: "_bar",
+    type: "direct",
+    value: "bar",
+    editable: true,
+  },
+  {
+    key: "_baz",
+    type: "direct",
+    value: "baz",
+    editable: false,
+  },
+]);
+
+// raw change
+useDevtoolsComponentState((payload, ctx) => {
+  payload.state.push(
+    ...[
+      {
+        key: "_bar",
+        type: "raw",
+        value: "bar",
+        editable: true,
+      },
+      {
+        key: "_baz",
+        type: "raw",
+        value: "baz",
+        editable: false,
+      },
+    ]
+  );
+});
+```
+
 ### Timeline events
 
 To add timeline events:

--- a/packages/vue-composable/package.json
+++ b/packages/vue-composable/package.json
@@ -52,5 +52,8 @@
   "peerDependencies2": {
     "@vue/composition-api": "^1.0.0-beta.2",
     "vue": "^2.6.10"
+  },
+  "peerDependencies": {
+    "@vue/runtime-core": "^3.0.0-rc.2"
   }
 }

--- a/packages/vue-composable/src/devtools/componentState.ts
+++ b/packages/vue-composable/src/devtools/componentState.ts
@@ -1,0 +1,102 @@
+import { ComponentState, InspectedComponentData } from "@vue/devtools-api";
+import { Context } from "vm";
+import { getCurrentInstance } from "../api";
+import { isArray, isFunction, isObject, unwrap } from "../utils";
+import { getDevtools } from "./api";
+
+export interface DevtoolsComponentStateOptions {
+  /**
+   * devtools grouping it can be `setup`, `firebase bindings`, `observables`, or a custom string
+   * @default setup
+   */
+  type: string;
+  /**
+   * if the key already in the state it will add it again
+   * @default false
+   */
+  multiple: boolean;
+}
+
+function getSetupStateExtra(raw: any) {
+  if (!raw) return {};
+
+  // NOTE vue3!
+  const isRef = !!raw.__v_isRef;
+  const isComputed = isRef && !!raw.effect;
+  const isReactive = !!raw.__v_reactive;
+
+  const objectType = isComputed
+    ? "Computed"
+    : isRef
+    ? "Ref"
+    : isReactive
+    ? "Reactive"
+    : null;
+
+  return {
+    ...(objectType ? { objectType } : {}),
+    ...(raw.effect ? { raw: raw.effect.raw.toString() } : {}),
+  };
+}
+
+export function useDevtoolsComponentState(
+  getState: (
+    instanceData: InspectedComponentData,
+    ctx: Context
+  ) => ComponentState[]
+): void;
+export function useDevtoolsComponentState(
+  state: ComponentState[],
+  options?: Omit<DevtoolsComponentStateOptions, "type">
+): void;
+export function useDevtoolsComponentState(
+  state: Record<string, object | ComponentState>,
+  options?: DevtoolsComponentStateOptions
+): void;
+export function useDevtoolsComponentState(
+  state:
+    | ComponentState[]
+    | Record<string, object | ComponentState>
+    | ((
+        instanceData: InspectedComponentData,
+        ctx: Context
+      ) => ComponentState[]),
+  options?: DevtoolsComponentStateOptions
+): void {
+  const instance = getCurrentInstance();
+  const api = getDevtools();
+
+  if (api && instance) {
+    api.on.inspectComponent((payload, ctx) => {
+      if (payload.componentInstance !== instance) return;
+
+      const [type, multiple] = isObject(options)
+        ? [options.type, options.multiple]
+        : ["setup", false];
+
+      if (isFunction(state)) {
+        state(payload.instanceData, ctx);
+        return;
+      }
+
+      let data = isArray(state)
+        ? state
+        : Object.keys(state).map(
+            (key) =>
+              ({
+                type,
+                key,
+                value: unwrap(state[key]),
+                ...getSetupStateExtra(state[key]),
+              } as ComponentState)
+          );
+
+      if (!multiple) {
+        const inserted = new Set(payload.instanceData.state.map((x) => x.key));
+        data = data.filter((x) => !inserted.has(x.key));
+      }
+
+      payload.instanceData.state.push(...data);
+    });
+  }
+}

--- a/packages/vue-composable/src/devtools/index.ts
+++ b/packages/vue-composable/src/devtools/index.ts
@@ -5,3 +5,4 @@ export * from "./install";
 // composables
 export * from "./inspector";
 export * from "./timelineLayer";
+export * from "./componentState";

--- a/packages/vue-composable/src/devtools/inspector.ts
+++ b/packages/vue-composable/src/devtools/inspector.ts
@@ -1,7 +1,7 @@
 import {
   CustomInspectorOptions,
   CustomInspectorNode,
-  CustomInspectorState
+  CustomInspectorState,
 } from "@vue/devtools-api";
 import { reactive, Ref, computed, toRaw, watch, ref } from "../api";
 import { RefTyped } from "../utils";
@@ -71,11 +71,9 @@ export function useDevtoolsInspector(
 
     // api.on.getInspectorState();
 
-    api.on.getInspectorTree(payload => {
+    api.on.getInspectorTree((payload) => {
       if (payload.inspectorId != id) return;
-      console.log();
       if (!nodes.value) return;
-
       const filter = payload.filter;
       let m = toRaw(nodes.value);
       if (payload.filter) {
@@ -84,14 +82,14 @@ export function useDevtoolsInspector(
         } else {
           // TODO better filtering, only currently filtering root nodes
           m = m.filter(
-            x => x.id.indexOf(filter) >= 0 || x.label.indexOf(filter) >= 0
+            (x) => x.id.indexOf(filter) >= 0 || x.label.indexOf(filter) >= 0
           );
         }
       }
       payload.rootNodes = m;
     });
 
-    api.on.getInspectorState(payload => {
+    api.on.getInspectorState((payload) => {
       if (payload.inspectorId != id) return;
 
       const node = byId.value.get(payload.nodeId);
@@ -109,12 +107,12 @@ export function useDevtoolsInspector(
       },
       {
         immediate: true,
-        deep: true
+        deep: true,
       }
     );
   }
 
   return {
-    nodes
+    nodes,
   };
 }

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,77 @@ app.use(VueComposableDevtools, {
 app.mount("#app");
 ```
 
+### Component State
+
+To add properties to the component inspector tab
+[ComponentState](https://github.com/vuejs/vue-devtools/blob/next/packages/api/src/api/component.ts#L68)
+
+```ts
+const bar = "bar";
+useDevtoolsComponentState(
+  {
+    bar,
+  },
+  {
+    type: "custom composable", // change group
+  }
+);
+
+const baz = () => "baz";
+useDevtoolsComponentState({ baz });
+// no duplicates added by default
+useDevtoolsComponentState({ baz });
+
+const the = 42;
+useDevtoolsComponentState({ the });
+// to allow multiple same key
+useDevtoolsComponentState({ the }, { duplicate: true });
+
+// use a devtools api list directly
+interface StateBase {
+  key: string;
+  value: any;
+  editable: boolean;
+  objectType?: "ref" | "reactive" | "computed" | "other";
+  raw?: string;
+  type?: string;
+}
+useDevtoolsComponentState([
+  {
+    key: "_bar",
+    type: "direct",
+    value: "bar",
+    editable: true,
+  },
+  {
+    key: "_baz",
+    type: "direct",
+    value: "baz",
+    editable: false,
+  },
+]);
+
+// raw change
+useDevtoolsComponentState((payload, ctx) => {
+  payload.state.push(
+    ...[
+      {
+        key: "_bar",
+        type: "raw",
+        value: "bar",
+        editable: true,
+      },
+      {
+        key: "_baz",
+        type: "raw",
+        value: "baz",
+        editable: false,
+      },
+    ]
+  );
+});
+```
+
 ### Timeline events
 
 To add timeline events:


### PR DESCRIPTION
Fix #566 

Allow to inject the state into the devtools component state


```ts
const bar = "bar";
useDevtoolsComponentState(
  {
    bar,
  },
  {
    type: "custom composable", // change group
  }
);

const baz = () => "baz";
useDevtoolsComponentState({ baz });
// no duplicates added by default
useDevtoolsComponentState({ baz });

const the = 42;
useDevtoolsComponentState({ the });
// to allow multiple same key
useDevtoolsComponentState({ the }, { duplicate: true });

// use a devtools api list directly
interface StateBase {
  key: string;
  value: any;
  editable: boolean;
  objectType?: "ref" | "reactive" | "computed" | "other";
  raw?: string;
  type?: string;
}
useDevtoolsComponentState([
  {
    key: "_bar",
    type: "direct",
    value: "bar",
    editable: true,
  },
  {
    key: "_baz",
    type: "direct",
    value: "baz",
    editable: false,
  },
]);

// raw change
useDevtoolsComponentState((payload, ctx) => {
  payload.state.push(
    ...[
      {
        key: "_bar",
        type: "raw",
        value: "bar",
        editable: true,
      },
      {
        key: "_baz",
        type: "raw",
        value: "baz",
        editable: false,
      },
    ]
  );
});
```

![image](https://user-images.githubusercontent.com/4620458/93167218-0eee5e80-f718-11ea-9ea9-2c7ffe692fb9.png)
